### PR TITLE
fix: одинарные кавычки в .env ломают TZ и расписание cron

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,22 +1,22 @@
 # Обязательные переменные
-YOOKASSA_SHOP_ID='change_me'
-YOOKASSA_API_KEY='change_me'
+YOOKASSA_SHOP_ID=change_me
+YOOKASSA_API_KEY=change_me
 
-MOY_NALOG_LOGIN='change_me'
-MOY_NALOG_PASSWORD='change_me'
+MOY_NALOG_LOGIN=change_me
+MOY_NALOG_PASSWORD=change_me
 
 # Таймзона контейнера. Используется для корректного времени в чеках и логах.
 # Список: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-TZ='Europe/Moscow'
+TZ=Europe/Moscow
 
 # Опциональные переменные
 # Специальный ID, используемый для идентификации устройства в Мой Налог (строго 21 символ).
 # Если не задан, будет сгенерирован автоматически на основе MOY_NALOG_LOGIN.
-#DEVICE_ID='CBDDvv8en4tprKHlqco4B'
+#DEVICE_ID=CBDDvv8en4tprKHlqco4B
 
 # Дата начала синхронизации (YYYY-MM-DD). 
 # Все платежи ДО этой даты (не включая эту дату) будут проигнорированы при первом запуске.
-SYNC_START_DATE='2026-01-30'
+SYNC_START_DATE=2026-01-30
 
 # Шаблон описания дохода в Мой Налог.
 # Доступные переменные для подстановки:
@@ -30,16 +30,16 @@ SYNC_START_DATE='2026-01-30'
 #   {merchant_customer_id}  — ID покупателя в вашей системе (пустая строка, если не задан)
 #
 # Примеры:
-#   INCOME_DESCRIPTION_TEMPLATE='Платеж #{description}'
-#   INCOME_DESCRIPTION_TEMPLATE='Оплата по счёту №{order_number}'
-#   INCOME_DESCRIPTION_TEMPLATE='Оплата услуг: {description} ({amount} руб.)'
-#   INCOME_DESCRIPTION_TEMPLATE='{customer_name} — счёт №{order_number}'
+#   INCOME_DESCRIPTION_TEMPLATE="Платеж #{description}"
+#   INCOME_DESCRIPTION_TEMPLATE="Оплата по счёту №{order_number}"
+#   INCOME_DESCRIPTION_TEMPLATE="Оплата услуг: {description} ({amount} руб.)"
+#   INCOME_DESCRIPTION_TEMPLATE="{customer_name} — счёт №{order_number}"
 #
 # Если не указано, используется значение по умолчанию: "Платеж #{description}"
-INCOME_DESCRIPTION_TEMPLATE='Платеж #{description}'
+INCOME_DESCRIPTION_TEMPLATE="Платеж #{description}"
 
 # Расписание выполнения синхронизации в формате cron
-CRON_SCHEDULE='0 */4 * * *'
+CRON_SCHEDULE="0 */4 * * *"
 
 # ──────────────────────────────────────────────
 # Telegram-уведомления (опционально)
@@ -56,7 +56,7 @@ CRON_SCHEDULE='0 */4 * * *'
 #                         Получить: правой кнопкой на тему → Copy Link, число в конце URL.
 #   TELEGRAM_PROXY      — SOCKS5 прокси, если сервер не имеет прямого доступа к api.telegram.org
 #
-#TELEGRAM_BOT_TOKEN='change_me'
-#TELEGRAM_CHAT_ID='change_me'
-#TELEGRAM_THREAD_ID='change_me'
-#TELEGRAM_PROXY='socks5://login:password@ip:1080'
+#TELEGRAM_BOT_TOKEN=change_me
+#TELEGRAM_CHAT_ID=change_me
+#TELEGRAM_THREAD_ID=change_me
+#TELEGRAM_PROXY=socks5://login:password@ip:1080

--- a/config.py
+++ b/config.py
@@ -1,7 +1,7 @@
 import os
 from dotenv import load_dotenv
 
-load_dotenv()
+load_dotenv(override=True)
 
 YOOKASSA_SHOP_ID = os.getenv("YOOKASSA_SHOP_ID")
 YOOKASSA_API_KEY = os.getenv("YOOKASSA_API_KEY")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,9 @@ TELEGRAM_STARTUP_NOTIFY=1 python /app/main.py
 
 CRON_SCHEDULE=$(python -c "import config; print(config.CRON_SCHEDULE)")
 
+TZ="${TZ#\'}"          ; TZ="${TZ%\'}"
+CRON_SCHEDULE="${CRON_SCHEDULE#\'}" ; CRON_SCHEDULE="${CRON_SCHEDULE%\'}"
+
 echo ""
 echo "Расписание: $CRON_SCHEDULE"
 echo "Переключение на регулярное выполнение..."


### PR DESCRIPTION
Docker Compose не срезает одинарные кавычки при загрузке переменных через
`env_file:`, поэтому значения вида `TZ='Europe/Moscow'` передавались
в контейнер буквально — вместе с кавычками. Поскольку `load_dotenv()`
по умолчанию не перезаписывает уже выставленные переменные, нормализация
через python-dotenv не срабатывала. В итоге cron получал невалидный
часовой пояс и некорректное расписание и молча не запускался.

Изменения:
- config.py: load_dotenv(override=True) — python-dotenv теперь всегда перечитывает .env и нормализует значения, даже если Compose уже выставил переменные
- entrypoint.sh: срезаем одинарные кавычки из $TZ и $CRON_SCHEDULE перед записью в cron-файл (TZ не проходит через python-dotenv — он интерполируется напрямую в shell)
- .env.example: убраны одинарные кавычки у всех значений; значения с пробелами или символом '#' обёрнуты в двойные кавычки, которые корректно обрабатывают и Compose, и python-dotenv