### PR TITLE
ci: tags-only builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,6 @@ name: Docker Publish
 
 on:
   push:
-    branches: [master]
     tags: ['[0-9]+.[0-9]+.[0-9]+']
   workflow_dispatch:
 
@@ -29,9 +28,8 @@ jobs:
         with:
           images: grandvan/yookassa-to-mynalog
           tags: |
-            type=ref,event=branch
             type=semver,pattern={{version}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest
 
       - name: Build and push
         uses: docker/build-push-action@v6


### PR DESCRIPTION
Меняет триггер CI: `branches: [master]` убран, `type=raw,value=latest,enable={{is_default_branch}}` заменён на безусловный `type=raw,value=latest`. После merge: CI собирает Docker-образ ТОЛЬКО при push semver-тега. Push в master/develop ничего не триггерят.